### PR TITLE
fixed failing test. NoMethodError: private method `remove'

### DIFF
--- a/test/persistent_http_test.rb
+++ b/test/persistent_http_test.rb
@@ -519,7 +519,7 @@ class PersistentHTTPTest < Test::Unit::TestCase
               rescue  Timeout::Error => e
                 # successfully failed to get a connection
               end
-              @http.remove(c1)
+              pool.remove(c1)
               Timeout.timeout(1) do
                 begin
                   pool.with_connection do |c4|


### PR DESCRIPTION
See issue https://github.com/bpardee/persistent_http/issues/1

Test suite was failing due to this.
