### PR TITLE
Add Ruby 2.1.0 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rvm:
   - 2.1.0
   - rbx
   - jruby-19mode
+matrix:
+  allow_failures:
+    - rvm: rbx


### PR DESCRIPTION
1. Added Ruby 2.1.0 to Travis config
2. Added Rubinius, but allow it to fail because it can timeout.
