### PR TITLE
Expose pool connection counts

### DIFF
--- a/lib/persistent_http.rb
+++ b/lib/persistent_http.rb
@@ -136,6 +136,11 @@ class PersistentHTTP
     @pool.pool_size
   end
 
+  # Return size of current used connections
+  def used_connection_count
+    @pool.size
+  end
+
   ##
   # Makes a request per +req+.  If +req+ is nil a Net::HTTP::Get is performed
   # against +default_path+.

--- a/lib/persistent_http.rb
+++ b/lib/persistent_http.rb
@@ -80,6 +80,10 @@ class PersistentHTTP
   attr_accessor :default_path
 
   ##
+  # Expose underlying GenePool object
+  attr_reader :pool
+
+  ##
   # Creates a new PersistentHTTP.
   #
   # Set +name+ to keep your connections apart from everybody else's.  Not
@@ -137,8 +141,13 @@ class PersistentHTTP
   end
 
   # Return size of current used connections
-  def used_connection_count
+  def used_connections
     @pool.size
+  end
+
+  # Return the size of available connections
+  def available_connections
+    pool_size - used_connections
   end
 
   ##


### PR DESCRIPTION
This PR relies on another from gene_pool:
https://github.com/bpardee/gene_pool/pull/5
- Add ability to pass throttle rate to gene_pool
- Added some helper readers to provide some gene pool counts
- Exposed gene pool object for application space pool manipulation/visibility (actual connections)
